### PR TITLE
Fix initialization with typed arrays and slow tree creation

### DIFF
--- a/kdtree.js
+++ b/kdtree.js
@@ -522,7 +522,7 @@ function createKDTree(points) {
     } else {
       type = "float64"
     }
-    indexed = ndarray(pool.malloc(n*(d+1)), [n, d+1])
+    indexed = ndarray(pool.malloc(n*(d+1), type), [n, d+1])
     ops.assign(indexed.hi(n,d), points)
   }
   for(var i=0; i<n; ++i) {

--- a/kdtree.js
+++ b/kdtree.js
@@ -491,6 +491,33 @@ proto.dispose = function kdtDispose() {
   this.length = 0
 }
 
+function Queue() {
+  this.data = []
+  this.offset = 0
+}
+
+Queue.prototype.size = function() {
+  return this.data.length - this.offset
+}
+
+Queue.prototype.push = function(item) {
+  return this.data.push(item)
+}
+
+Queue.prototype.pop = function() {
+  if (this.size() === 0) {
+    return undefined
+  }
+
+  var ret = this.data[this.offset]
+  this.offset++
+  if (this.data.length > 1024 && this.offset * 2 > this.data.length) {
+    this.data = this.data.slice(this.offset)
+    this.offset = 0
+  }
+  return ret
+}
+
 function createKDTree(points) {
   var n, d, indexed
   if(Array.isArray(points)) {
@@ -539,9 +566,10 @@ function createKDTree(points) {
   var sel_cmp = ndselect.compile(indexed.order, true, indexed.dtype)
 
   //Walk tree in level order
-  var toVisit = [indexed]
+  var toVisit = new Queue()
+  toVisit.push(indexed)
   while(pointer < n) {
-    var head = toVisit.shift()
+    var head = toVisit.pop()
     var array = head
     var nn = array.shape[0]|0
     

--- a/test/test.js
+++ b/test/test.js
@@ -5,6 +5,7 @@ var tape = require("tape")
 var dup = require("dup")
 var iota = require("iota-array")
 var unpack = require("ndarray-unpack")
+var ndarray = require("ndarray")
 
 function checkTreeInvariants(t, tree, points) {
   t.equals(tree.length, points.length, "checking point count")
@@ -49,6 +50,11 @@ tape("kdtree-constructor", function(t) {
   var emptyTree = createTree([])
   t.equals(emptyTree.length, 0, "check empty tree length")
   t.equals(emptyTree.dimension, 0, "checking empty tree dimension")
+
+  var data = ndarray(new Uint8Array([1, 2, 3, 4, 5, 6]), [2, 3])
+  var tree = createTree(data)
+  t.equals(tree.length, 2, "check non-empty tree length")
+  t.equals(tree.dimension, 3, "checking empty tree dimension")
 
   t.end()
 })


### PR DESCRIPTION
(This is the same as #8, but from a different fork.)

`static-kdtree` was previously unusable with typed arrays.
Fixes #9
