### PR TITLE
Improve deserialize performance by 19%

### DIFF
--- a/kdtree.js
+++ b/kdtree.js
@@ -620,14 +620,10 @@ function deserializeKDTree(data) {
   if(points) {
     var nd = points.length
     var pointArray = pool.mallocFloat64(nd)
-    for(var i=0; i<nd; ++i) {
-      pointArray[i] = points[i]
-    }
+    pointArray.set(points);
     var n = ids.length
     var idArray = pool.mallocInt32(n)
-    for(var i=0; i<n; ++i) {
-      idArray[i] = ids[i]
-    }
+    idArray.set(ids)
     var d = (nd/n)|0
     return new KDTree(
       ndarray(pointArray, [n,d]),


### PR DESCRIPTION
[TypedArray.set](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/set) copies memory in the JS engine which is often faster than looping through the array.

Its well-supported in all browsers:
![image](https://user-images.githubusercontent.com/709451/102307276-06751200-3f19-11eb-8f10-2a4f5717e299.png)

I changed deserialize to use `.set` instead of looping through the array and these were the results:

```
Deserialize (using TypedArray.set): 167.189ms
Deserialize (using for loop): 199.565ms
```

This was the code:
```ts
var pts = dup(100000).map(function() {
  return dup(4).map(Math.random)
})
var tree = createTree(pts)

var data = tree.serialize()
console.time("Deserialize (using TypedArray.set)")
for (let i = 0; i < 100;i++) {
  createTree._deserialize(data)
}
console.timeEnd("Deserialize (using TypedArray.set)")
console.time("Deserialize (using for loop)")
for (let i = 0; i < 100;i++) {
  createTree.deserialize(data)
}
console.timeEnd("Deserialize (using for loop)")
```

I ran this with `--nolazy` so that the code is compiled instead of lazily compiled.  This was run with Node.js `14.7.0` 

I manually ran the tests and they passed.
